### PR TITLE
feat: get password/hash from a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Note that when using a proxy you might want to consider including the `-M` flag 
 
 * `-u`,`--username` - Username for bind
 * `-p`,`--password` - Password for bind
+* `--passfile` - Path to a file containing the password for bind
 * `-P`,`--port` - Custom port for the connection (default: `389`)
 * `-r`,`--rootDN <distinguishedName>` - Initial root DN (default: automatic)
 * `-f`,`--filter <search filter>` - Initial LDAP search filter (default: `(objectClass=*)`)
@@ -95,6 +96,7 @@ Note that when using a proxy you might want to consider including the `-M` flag 
 * `-G`,`--paging` - Default paging size for regular queries
 * `-d`,`--domain` - Domain for NTLM bind
 * `-H`,`--hashes` - Hashes for NTLM bind
+* `--hashfile` - Path to a file containing the hashes for NTLM bind
 * `-x`,`--socks` - URI of SOCKS proxy to use for connection (supports `socks4://`, `socks4a://` or `socks5://` schemas)
 
 ## Keybindings

--- a/main.go
+++ b/main.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/Macmod/godap/utils"
@@ -16,13 +18,15 @@ import (
 )
 
 var (
-	ldapServer   string
-	ldapPort     int
-	ldapUsername string
-	ldapPassword string
-	ntlmHash     string
-	ntlmDomain   string
-	socksServer  string
+	ldapServer       string
+	ldapPort         int
+	ldapUsername     string
+	ldapPassword     string
+	ldapPasswordFile string
+	ntlmHash         string
+	ntlmHashFile     string
+	ntlmDomain       string
+	socksServer      string
 
 	emojis       bool
 	colors       bool
@@ -384,7 +388,6 @@ func setupApp() {
 	if err := app.SetRoot(appPanel, true).SetFocus(treePanel).Run(); err != nil {
 		log.Fatal(err)
 	}
-
 }
 
 func main() {
@@ -394,6 +397,22 @@ func main() {
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			ldapServer = args[0]
+
+			if ldapPasswordFile != "" {
+				pw, err := os.ReadFile(ldapPasswordFile)
+				if err != nil {
+					log.Fatal(err)
+				}
+				ldapPassword = strings.TrimSpace(string(pw))
+			}
+			if ntlmHashFile != "" {
+				hash, err := os.ReadFile(ntlmHashFile)
+				if err != nil {
+					log.Fatal(err)
+				}
+				ntlmHash = strings.TrimSpace(string(hash))
+			}
+
 			setupApp()
 		},
 	}
@@ -401,8 +420,10 @@ func main() {
 	rootCmd.Flags().IntVarP(&ldapPort, "port", "P", 389, "LDAP server port")
 	rootCmd.Flags().StringVarP(&ldapUsername, "username", "u", "", "LDAP username")
 	rootCmd.Flags().StringVarP(&ldapPassword, "password", "p", "", "LDAP password")
+	rootCmd.Flags().StringVarP(&ldapPasswordFile, "passfile", "", "", "Path to a file containing the LDAP password")
 	rootCmd.Flags().StringVarP(&ntlmDomain, "domain", "d", "", "Domain for NTLM bind")
 	rootCmd.Flags().StringVarP(&ntlmHash, "hashes", "H", "", "NTLM hash")
+	rootCmd.Flags().StringVarP(&ntlmHashFile, "hashfile", "", "", "Path to a file containing the NTLM hash")
 	rootCmd.Flags().StringVarP(&rootDN, "rootDN", "r", "", "Initial root DN")
 	rootCmd.Flags().StringVarP(&searchFilter, "filter", "f", "(objectClass=*)", "Initial LDAP search filter")
 	rootCmd.Flags().BoolVarP(&emojis, "emojis", "E", true, "Prefix objects with emojis")


### PR DESCRIPTION
This allows the user to pass a filepath to get the LDAP password/NTLM hash from rather than exposing them to shell history/process table