### PR TITLE
Add a timefmt argument to allow custom date/time

### DIFF
--- a/gpo.go
+++ b/gpo.go
@@ -308,8 +308,8 @@ func updateGPOEntries() {
 		gpoChanged := entry.GetAttributeValue("whenChanged")
 
 		gpoListPanel.SetCellSimple(idx+1, 0, gpoName)
-		gpoListPanel.SetCellSimple(idx+1, 1, utils.FormatLDAPTime(gpoCreated))
-		gpoListPanel.SetCellSimple(idx+1, 2, utils.FormatLDAPTime(gpoChanged))
+		gpoListPanel.SetCellSimple(idx+1, 1, utils.FormatLDAPTime(gpoCreated, timeFormat))
+		gpoListPanel.SetCellSimple(idx+1, 2, utils.FormatLDAPTime(gpoChanged, timeFormat))
 		gpoListPanel.SetCellSimple(idx+1, 3, gpoGuid)
 	}
 

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ var (
 	socksServer      string
 	targetSpn        string
 	kdcHost          string
+	timeFormat       string
 
 	kerberos     bool
 	emojis       bool
@@ -427,6 +428,9 @@ func setupApp() {
 		SetTitle("Deleted (d)").
 		SetBorder(true)
 
+	// Time format setup
+	timeFormat = setupTimeFormat(timeFormat)
+
 	err := setupLDAPConn()
 	if err != nil {
 		log.Fatal(err)
@@ -516,6 +520,24 @@ func setupApp() {
 	}
 }
 
+// setupTimeFormat returns the time format string based on the given format code.
+// The format code can be one of the following:
+// - "EU" or empty string: returns the format "02/01/2006 15:04:05" (day/month/year hour:minute:second)
+// - "US": returns the format "01/02/2006 15:04:05" (month/day/year hour:minute:second)
+// - "ISO": returns the format "2006-01-02 15:04:05" (year-month-day hour:minute:second)
+// If the format code is not recognized, it assumed to be a golang time format and is returned unchanged.
+func setupTimeFormat(f string) string {
+	switch f {
+	case "EU", "":
+		return "02/01/2006 15:04:05"
+	case "US":
+		return "01/02/2006 15:04:05"
+	case "ISO":
+		return "2006-01-02 15:04:05"
+	}
+	return f
+}
+
 func main() {
 	tview.Styles = baseTheme
 
@@ -570,6 +592,7 @@ func main() {
 	rootCmd.Flags().BoolVarP(&ldaps, "ldaps", "S", false, "Use LDAPS for initial connection")
 	rootCmd.Flags().StringVarP(&socksServer, "socks", "x", "", "Use a SOCKS proxy for initial connection")
 	rootCmd.Flags().StringVarP(&kdcHost, "kdc", "", "", "Address of the KDC to use with Kerberos authentication (optional: only if the KDC differs from the specified LDAP server)")
+	rootCmd.Flags().StringVarP(&timeFormat, "timefmt", "", "", "Time format for LDAP timestamps")
 
 	versionCmd := &cobra.Command{
 		Use:                   "version",

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestSetupTimeFormat(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "EU format",
+			input:    "EU",
+			expected: "02/01/2006 15:04:05",
+		},
+		{
+			name:     "Empty string",
+			input:    "",
+			expected: "02/01/2006 15:04:05",
+		},
+		{
+			name:     "US format",
+			input:    "US",
+			expected: "01/02/2006 15:04:05",
+		},
+		{
+			name:     "ISO format",
+			input:    "ISO",
+			expected: "2006-01-02 15:04:05",
+		},
+		{
+			name:     "Custom format",
+			input:    "20060102150405",
+			expected: "20060102150405",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := setupTimeFormat(tt.input)
+			if result != tt.expected {
+				t.Errorf("got %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}

--- a/tree.go
+++ b/tree.go
@@ -374,7 +374,7 @@ func reloadAttributesPanel(node *tview.TreeNode, attrsTable *tview.Table, useCac
 		attrsTable.SetCell(row, 0, tview.NewTableCell(cellName))
 
 		if formatAttrs {
-			cellValues = utils.FormatLDAPAttribute(attribute)
+			cellValues = utils.FormatLDAPAttribute(attribute, timeFormat)
 		} else {
 			cellValues = attribute.Values
 		}

--- a/utils/ldapformat.go
+++ b/utils/ldapformat.go
@@ -10,7 +10,7 @@ import (
 	"github.com/go-ldap/ldap/v3"
 )
 
-func FormatLDAPTime(val string) string {
+func FormatLDAPTime(val, format string) string {
 	layout := "20060102150405.0Z"
 	t, err := time.Parse(layout, val)
 	if err != nil {
@@ -19,13 +19,10 @@ func FormatLDAPTime(val string) string {
 
 	distString := GetTimeDistString(time.Since(t))
 
-	return fmt.Sprintf(
-		"%02d/%02d/%d %02d:%02d:%02d %s", t.Day(), t.Month(), t.Year(),
-		t.Hour(), t.Minute(), t.Second(), distString,
-	)
+	return fmt.Sprintf("%s %s", t.Format(format), distString)
 }
 
-func FormatLDAPAttribute(attr *ldap.EntryAttribute) []string {
+func FormatLDAPAttribute(attr *ldap.EntryAttribute, timeFormat string) []string {
 	var formattedEntries = attr.Values
 
 	if len(attr.Values) == 0 {
@@ -40,7 +37,7 @@ func FormatLDAPAttribute(attr *ldap.EntryAttribute) []string {
 			formattedEntries = []string{"GUID{" + ConvertGUID(hex.EncodeToString(attr.ByteValues[idx])) + "}"}
 		case "whenCreated", "whenChanged":
 			formattedEntries = []string{
-				FormatLDAPTime(val),
+				FormatLDAPTime(val, timeFormat),
 			}
 		case "lastLogonTimestamp", "accountExpires", "badPasswordTime", "lastLogoff", "lastLogon", "pwdLastSet", "creationTime", "lockoutTime":
 			if val == "0" {
@@ -61,7 +58,7 @@ func FormatLDAPAttribute(attr *ldap.EntryAttribute) []string {
 
 			distString := GetTimeDistString(time.Since(t))
 
-			formattedEntries = []string{fmt.Sprintf("%02d/%02d/%d %02d:%02d:%02d %s", t.Day(), t.Month(), t.Year(), t.Hour(), t.Minute(), t.Second(), distString)}
+			formattedEntries = []string{fmt.Sprintf("%s %s", t.Format(timeFormat), distString)}
 		case "userAccountControl":
 			uacInt, _ := strconv.Atoi(val)
 


### PR DESCRIPTION
Proof of concept for #6 

Allow the user to configure the date/time formatting. Offer a few pre-defined options and try anything else as a go time format string.

Formats:
- EU: "02/01/2006 15:04:05"
- US: "01/02/2006 15:04:05"
- ISO8601: "2006-01-02 15:04:05"
- "20060102 150405"

examples:
--timefmt=US
--timefmt=ISO8601
--timefmt="20060102 150405"