### PR TITLE
fix(version): update displayed version to v2.10.10

### DIFF
--- a/tui/main.go
+++ b/tui/main.go
@@ -24,7 +24,7 @@ import (
 	"software.sslmate.com/src/go-pkcs12"
 )
 
-var GodapVer = "Godap v2.10.9"
+var GodapVer = "Godap v2.10.10"
 var (
 	LdapServer       string
 	LdapPort         int


### PR DESCRIPTION
## Summary
- bump `GodapVer` from `Godap v2.10.9` to `Godap v2.10.10`

## Context
- fixes `godap version` output mismatch seen in https://github.com/Homebrew/homebrew-core/pull/270170
